### PR TITLE
Refactor service

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -15,14 +15,10 @@ oauth2_scheme = OAuth2PasswordBearer(
 
 
 def auth_service_factory(repository_session: RepositorySession) -> AuthService:
-    user_repository = user_repository_factory(repository_session.new_operator)
-    auth_record_repository = auth_record_repository_factory(
-        repository_session.new_operator
-    )
     return AuthService(
         AuthServiceConfig.from_env(),
-        user_repository,
-        auth_record_repository,
+        user_repository_factory,
+        auth_record_repository_factory,
         repository_session,
     )
 

--- a/app/repositories/auth.py
+++ b/app/repositories/auth.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TypeVar
+from typing import Callable, TypeAlias, TypeVar
 
 from psycopg import Cursor
 
@@ -23,6 +23,11 @@ class AuthRecordRepository(AbstractRepository[Operator]):
             EntityNotFoundError: If no record is found with the provided username
         """
         pass
+
+
+AuthRecordRepositoryFactory: TypeAlias = Callable[
+    [Callable[[], Operator]], AuthRecordRepository[Operator]
+]
 
 
 def auth_record_repository_factory(new_operator):

--- a/app/repositories/order.py
+++ b/app/repositories/order.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TypeVar
+from typing import Callable, TypeAlias, TypeVar
 
 from psycopg import Cursor
 
@@ -23,6 +23,11 @@ class OrderRepository(AbstractRepository[Operator]):
         but for the current project scope, the existing arrangement is sufficient.
         """
         pass
+
+
+OrderRepositoryFactory: TypeAlias = Callable[
+    [Callable[[], Operator]], OrderRepository[Operator]
+]
 
 
 def order_repository_factory(new_operator):

--- a/app/repositories/product.py
+++ b/app/repositories/product.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TypeVar
+from typing import Callable, TypeAlias, TypeVar
 
 from psycopg import Cursor
 
@@ -22,6 +22,11 @@ class ProductRepository(AbstractRepository[Operator]):
             EntityNotFoundError: If no product is found with the provided id.
         """
         pass
+
+
+ProductRepositoryFactory: TypeAlias = Callable[
+    [Callable[[], Operator]], ProductRepository[Operator]
+]
 
 
 def product_repository_factory(new_operator):

--- a/app/repositories/user.py
+++ b/app/repositories/user.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import TypeVar
+from typing import Callable, TypeAlias, TypeVar
 
 from psycopg import Cursor
 from app.models.user import User
@@ -22,6 +22,11 @@ class UserRepository(AbstractRepository[Operator]):
             EntityNotFoundError: If no user is found with the provided id.
         """
         pass
+
+
+UserRepositoryFactory: TypeAlias = Callable[
+    [Callable[[], Operator]], UserRepository[Operator]
+]
 
 
 def user_repository_factory(new_operator):

--- a/app/routers/orders.py
+++ b/app/routers/orders.py
@@ -42,12 +42,11 @@ def place_order(
     current_user_id: Annotated[str, Depends(get_current_user_id)],
     repository_session: Annotated[RepositorySession, Depends(get_repository_session)],
 ):
-    user_repository = user_repository_factory(repository_session.new_operator)
-    product_repository = product_repository_factory(repository_session.new_operator)
-    order_repository = order_repository_factory(repository_session.new_operator)
-
     order_service = OrderService(
-        user_repository, product_repository, order_repository, repository_session
+        user_repository_factory,
+        product_repository_factory,
+        order_repository_factory,
+        repository_session,
     )
 
     try:

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -9,10 +9,10 @@ from passlib.context import CryptContext
 from app.err import MyValueError
 from app.models.auth import AuthInput, AuthRecord
 from app.models.user import USER_INITIAL_BALANCE, User
-from app.repositories.auth import AuthRecordRepository
+from app.repositories.auth import AuthRecordRepository, AuthRecordRepositoryFactory
 from app.repositories.err import EntityNotFoundError
 from app.repositories.base import RepositorySession
-from app.repositories.user import UserRepository
+from app.repositories.user import UserRepository, UserRepositoryFactory
 
 Operator = TypeVar("Operator")
 
@@ -65,13 +65,17 @@ class AuthService(Generic[Operator]):
     def __init__(
         self,
         auth_service_config: AuthServiceConfig,
-        user_repository: UserRepository[Operator],
-        auth_repository: AuthRecordRepository[Operator],
+        user_repository_factory: UserRepositoryFactory[Operator],
+        auth_repository_factory: AuthRecordRepositoryFactory[Operator],
         repository_session: RepositorySession[Operator],
     ):
         self._auth_service_config = auth_service_config
-        self._user_repository = user_repository
-        self._auth_repository = auth_repository
+        self._user_repository: UserRepository[Operator] = user_repository_factory(
+            repository_session.new_operator
+        )
+        self._auth_repository: AuthRecordRepository[Operator] = auth_repository_factory(
+            repository_session.new_operator
+        )
         self._session = repository_session
 
     def sign_up(self, auth_input: AuthInput):

--- a/app/services/order.py
+++ b/app/services/order.py
@@ -4,10 +4,10 @@ from app.err import MyValueError
 from app.models.order import Order, PurchaseInfo
 from app.models.product import Product
 from app.models.user import User
-from app.repositories.order import OrderRepository
-from app.repositories.product import ProductRepository
+from app.repositories.order import OrderRepository, OrderRepositoryFactory
+from app.repositories.product import ProductRepository, ProductRepositoryFactory
 from app.repositories.base import RepositorySession
-from app.repositories.user import UserRepository
+from app.repositories.user import UserRepository, UserRepositoryFactory
 
 Operator = TypeVar("Operator")
 
@@ -28,14 +28,20 @@ class PlaceOrderError(MyValueError):
 class OrderService(Generic[Operator]):
     def __init__(
         self,
-        user_repository: UserRepository[Operator],
-        product_repository: ProductRepository[Operator],
-        order_repository: OrderRepository[Operator],
+        user_repository_factory: UserRepositoryFactory[Operator],
+        product_repository_factory: ProductRepositoryFactory[Operator],
+        order_repository_factory: OrderRepositoryFactory[Operator],
         repository_session: RepositorySession[Operator],
     ):
-        self._user_repository = user_repository
-        self._product_repository = product_repository
-        self._order_repository = order_repository
+        self._user_repository: UserRepository[Operator] = user_repository_factory(
+            repository_session.new_operator
+        )
+        self._product_repository: ProductRepository[Operator] = (
+            product_repository_factory(repository_session.new_operator)
+        )
+        self._order_repository: OrderRepository[Operator] = order_repository_factory(
+            repository_session.new_operator
+        )
         self._session = repository_session
 
     def place_order(self, user_id: str, purchase_info: PurchaseInfo):

--- a/tests/services/test_auth.py
+++ b/tests/services/test_auth.py
@@ -57,10 +57,6 @@ class AuthServiceFixture(Generic[Operator]):
 
 @pytest.fixture
 def auth_service_fixture(repository_session: RepositorySession):
-    user_repository = user_repository_factory(repository_session.new_operator)
-    auth_record_repository = auth_record_repository_factory(
-        repository_session.new_operator
-    )
     auth_service_config = AuthServiceConfig.from_env()
 
     def auth_service_factory(
@@ -68,10 +64,15 @@ def auth_service_fixture(repository_session: RepositorySession):
     ):
         return AuthService(
             auth_service_config=auth_service_config,
-            user_repository=user_repository,
-            auth_repository=auth_record_repository,
+            user_repository_factory=user_repository_factory,
+            auth_repository_factory=auth_record_repository_factory,
             repository_session=repository_session,
         )
+
+    user_repository = user_repository_factory(repository_session.new_operator)
+    auth_record_repository = auth_record_repository_factory(
+        repository_session.new_operator
+    )
 
     return AuthServiceFixture(
         user_repository,

--- a/tests/services/test_order.py
+++ b/tests/services/test_order.py
@@ -88,17 +88,17 @@ class OrderServiceFixture(Generic[Operator]):
 
 @pytest.fixture
 def order_service_fixture(repository_session: RepositorySession):
-    user_repository = user_repository_factory(repository_session.new_operator)
-    product_repository = product_repository_factory(repository_session.new_operator)
-    order_repository = order_repository_factory(repository_session.new_operator)
     order_service = OrderService(
-        user_repository, product_repository, order_repository, repository_session
+        user_repository_factory,
+        product_repository_factory,
+        order_repository_factory,
+        repository_session,
     )
     return OrderServiceFixture(
         order_service,
-        user_repository,
-        product_repository,
-        order_repository,
+        user_repository_factory(repository_session.new_operator),
+        product_repository_factory(repository_session.new_operator),
+        order_repository_factory(repository_session.new_operator),
         repository_session,
     )
 


### PR DESCRIPTION
Refactor the service to accept repository factory instead of repo directly.

May make more sense if the repository is constructed base on the session of that service, so that the repositories are explictly under the transaction control of the session.